### PR TITLE
Fix smartParser errors

### DIFF
--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -1,6 +1,6 @@
 export interface AvastarParsedDataPoint {
-  platform: 'facebook' | 'google' | 'other'; // suggesting by github copilot not sure if accurate
-  source: string; // could be more precise, since it's a path out of the path references file
+  action_type: string; 
+  data_origin: 'volunteered' | 'observed' | 'inferred' | 'other'; // suggesting by github copilot not sure if accurate
   data_type:
     | 'Locational'
     | 'Behavioural'
@@ -13,10 +13,10 @@ export interface AvastarParsedDataPoint {
     | 'Socio-demographic'
     | 'Contractual'
     | 'Other';
-  data_origin: 'volunteered' | 'observed' | 'inferred' | 'other'; // suggesting by github copilot not sure if accurate
-  action: string; // same here, maybe there is an enum for this
-  details?: string[]; // same here
-  interaction_date?: string;
+  platform: 'facebook' | 'google' | 'other'; // suggesting by github copilot not sure if accurate
+  timestamp?: string;
+  details?: string[];
+  source?: string; // could be more precise, since it's a path out of the path references file
 }
 
 export type AvastarParsedDataPointState = {
@@ -31,11 +31,11 @@ export type APDPAction = {
 export type DispatchType = (args: APDPAction) => APDPAction;
 
 export const getEmptyDataPoint = (): AvastarParsedDataPoint => ({
-  platform: 'other',
-  source: '',
-  data_type: 'Other',
+  action_type: '',
   data_origin: 'other',
-  action: '',
+  data_type: 'Other',
+  platform: 'other',
+  timestamp: '',
   details: [],
-  interaction_date: '',
+  source: '',
 });

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -2,17 +2,17 @@ export interface AvastarParsedDataPoint {
   action_type: string; 
   data_origin: 'volunteered' | 'observed' | 'inferred' | 'other'; // suggesting by github copilot not sure if accurate
   data_type:
-    | 'Locational'
-    | 'Behavioural'
-    | 'Communications'
-    | 'Technical'
-    | 'Social relationships'
-    | 'Contact'
-    | 'Transactional'
-    | 'Financial'
-    | 'Socio-demographic'
-    | 'Contractual'
-    | 'Other';
+    | 'locational'
+    | 'behavioural'
+    | 'communications'
+    | 'technical'
+    | 'social relationships'
+    | 'contact'
+    | 'transactional'
+    | 'financial'
+    | 'socio-demographic'
+    | 'contractual'
+    | 'other';
   platform: 'facebook' | 'google' | 'other'; // suggesting by github copilot not sure if accurate
   timestamp?: string;
   details?: string[];
@@ -32,7 +32,7 @@ export type DispatchType = (args: APDPAction) => APDPAction;
 export const getEmptyDataPoint = (): AvastarParsedDataPoint => ({
   action_type: '',
   data_origin: 'other',
-  data_type: 'Other',
+  data_type: 'other',
   platform: 'other',
   timestamp: '',
   details: []

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -16,7 +16,6 @@ export interface AvastarParsedDataPoint {
   platform: 'facebook' | 'google' | 'other'; // suggesting by github copilot not sure if accurate
   timestamp?: string;
   details?: string[];
-  source?: string; // could be more precise, since it's a path out of the path references file
 }
 
 export type AvastarParsedDataPointState = {
@@ -36,6 +35,5 @@ export const getEmptyDataPoint = (): AvastarParsedDataPoint => ({
   data_type: 'Other',
   platform: 'other',
   timestamp: '',
-  details: [],
-  source: '',
+  details: []
 });

--- a/src/utils/parsingModel.json
+++ b/src/utils/parsingModel.json
@@ -1801,7 +1801,7 @@
     },
     "location/device_location.json": {
       "language": "en",
-      "comment": "TBD",
+      "comment": "Location of the user inferred from the phone number of his device (country code)",
       "file_structure_properties":{
         "depth": 1,
         "has_single_data_point": false,
@@ -1809,10 +1809,10 @@
         "data_point_selector": "",
         "nested_data_point_selector": ""
       },
-      "groups_admined_v2": {
+      "phone_number_location_v2": {
         "entries": [
           {
-            "action_type": "TBD (device_location.json)"
+            "action_type": "Location of your device inferred from your phone number"
           },
           {
             "data_origin": "Observed"

--- a/src/utils/parsingModel.json
+++ b/src/utils/parsingModel.json
@@ -805,7 +805,7 @@
       "file_structure_properties":{
         "depth": 2,
         "has_single_data_point": false,
-        "has_multiple_nested_objects": false,
+        "has_multiple_nested_objects": true,
         "data_point_selector": "",
         "nested_data_point_selector": ""
       },
@@ -2531,7 +2531,7 @@
       "file_structure_properties":{
         "depth": 3,
         "has_single_data_point": false,
-        "has_multiple_nested_objects": false,
+        "has_multiple_nested_objects": true,
         "data_point_selector": "",
         "nested_data_point_selector": ""
       },

--- a/src/utils/smartParser.ts
+++ b/src/utils/smartParser.ts
@@ -174,7 +174,7 @@ export const smartParser = (
                       ) {
                         parsedDataPoint[avastarParsedDataPointProperties[k]] = (
                           parsingModel as any
-                        )[filePathModel]['None'][categorySelector][k][
+                        )[filePathModel][nestedArrayName][categorySelector][k][
                           avastarParsedDataPointProperties[k]
                         ];
                       }
@@ -191,10 +191,18 @@ export const smartParser = (
                         fileContent[nestedArrayName][categorySelector].length;
                         j++
                       ) {
-                        const parsedDataPoint = getParsedDataPoint(
-                          filePathModel,
-                          nestedArrayName
-                        );
+                        const parsedDataPoint = getEmptyDataPoint();
+                        for (
+                          let k = 0;
+                          k < avastarParsedDataPointProperties.length;
+                          k++
+                        ) {
+                          parsedDataPoint[avastarParsedDataPointProperties[k]] = (
+                            parsingModel as any
+                          )[filePathModel][nestedArrayName][categorySelector][k][
+                            avastarParsedDataPointProperties[k]
+                          ];
+                        }
                         smartData.push(parsedDataPoint);
                       }
                     }
@@ -252,11 +260,18 @@ export const smartParser = (
                         categorySelector
                       ] != null
                     ) {
-                      // Check if the name of the categorySelector parsed is in the parsingModel
-                      const parsedDataPoint = getParsedDataPoint(
-                        filePathModel,
-                        nestedArrayName
-                      );
+                      const parsedDataPoint = getEmptyDataPoint();
+                      for (
+                        let k = 0;
+                        k < avastarParsedDataPointProperties.length;
+                        k++
+                      ) {
+                        parsedDataPoint[avastarParsedDataPointProperties[k]] = (
+                          parsingModel as any
+                        )[filePathModel][nestedArrayName][categorySelector][k][
+                          avastarParsedDataPointProperties[k]
+                        ];
+                      }
                       smartData.push(parsedDataPoint);
                     }
                   }
@@ -267,6 +282,9 @@ export const smartParser = (
             const nestedArrayName = String(Object.keys(fileContent));
 
             for (let j = 0; j < fileContent[nestedArrayName].length; j++) {
+
+              let categorySelector = fileContent[nestedArrayName][j]['name'];
+
               let hasPropertyEntries =
                 fileContent[nestedArrayName][j].hasOwnProperty('entries'); // Check if the data point selector in the nested array is either "children" or "entries".
 
@@ -276,13 +294,21 @@ export const smartParser = (
                   k < fileContent[nestedArrayName][j]['entries'].length;
                   k++
                 ) {
-                  const parsedDataPoint = getParsedDataPoint(
-                    filePathModel,
-                    nestedArrayName
-                  );
+                  const parsedDataPoint = getEmptyDataPoint();
+                    for (
+                      let m = 0;
+                      m < avastarParsedDataPointProperties.length;
+                      m++
+                    ) {
+                      parsedDataPoint[avastarParsedDataPointProperties[m]] = (
+                        parsingModel as any
+                      )[filePathModel][nestedArrayName][categorySelector][m][
+                        avastarParsedDataPointProperties[m]
+                      ];
+                    }
                   smartData.push(parsedDataPoint);
                 }
-              } else {
+              } else { 
                 let categorySelector = fileContent[nestedArrayName][j]['name'];
 
                 for (
@@ -305,7 +331,7 @@ export const smartParser = (
                     ) {
                       parsedDataPoint[avastarParsedDataPointProperties[m]] = (
                         parsingModel as any
-                      )[filePathModel]['None'][categorySelector][m][
+                      )[filePathModel][nestedArrayName][categorySelector][m][
                         avastarParsedDataPointProperties[m]
                       ];
                     }


### PR DESCRIPTION
🚧 L'objectif de cette PR est de régler des problèmes qui sont apparus sur le smartParser après le merge de feature/redux. Quand j'uploadais mes fichiers, `avastarParsedData` me renvoyait uniquement des valeurs "other" pour chacune des propriétés (à l'exception de data_type) et des erreurs sur des fichiers spécifiques.

Voici la liste des principales modifications effectuées, nécessaires au bon fonctionnement du smartParser :
* Modification de l'ordre des propriétés de `AvastarParsedDataPoint` dans `dataTypes.ts`
* Renaming de certaines propriétés de `AvastarParsedDataPoint` dans `dataTypes.ts`  
* Suppression de la propriété source dans `dataTypes.ts`
* Updates au sein de la fonction smartParser dans `smartParser.ts`
* Quelques changements mineurs dans `parsingModel.json`

Avant de merger cette PR, faire un maximum de tests avec ses propres fichiers.