### PR TITLE
Pull years data exchange kpi

### DIFF
--- a/src/components/Overview/Charts/ForceDirectedGraph.tsx
+++ b/src/components/Overview/Charts/ForceDirectedGraph.tsx
@@ -64,10 +64,12 @@ export default function ForceGraph(props: PropsFilter) {
 
   // Pick randomly 150 data points coming from the filtered data object
   // An "input" filter component will be created later to allow the user select the upper bound of the slice
-  if (props.nodes === "") {
-    var data = filteredData.sort(() => 0.5 - Math.random()).slice(0, 50);
+  if (props.nodes === '') {
+    var data = filteredData.sort(() => 0.5 - Math.random()).slice(0, 100);
   } else {
-    data = filteredData.sort(() => 0.5 - Math.random()).slice(0, parseInt(props.nodes));
+    data = filteredData
+      .sort(() => 0.5 - Math.random())
+      .slice(0, parseInt(props.nodes));
   }
 
   // Transform filtered data object into the right shape for the force graph (nodes and links)

--- a/src/components/Overview/OverviewProfile.tsx
+++ b/src/components/Overview/OverviewProfile.tsx
@@ -15,7 +15,7 @@ import { useSelector, shallowEqual } from 'react-redux';
 import {
   AvastarParsedDataPoint,
   AvastarParsedDataPointState,
-  PropsFilter
+  PropsFilter,
 } from '../../types/dataTypes';
 
 // Styled-components
@@ -115,6 +115,23 @@ export default function OverviewProfile(props: PropsFilter) {
     }
   }
 
+  var yearsDataExchange = undefined;
+  for (let i = 0; i < avastarParsedDataFiltered.length; i++) {
+    if (
+      avastarParsedDataFiltered[i].action_type ===
+        'Facebook account creation date' &&
+      avastarParsedDataFiltered[i].timestamp !== null
+    ) {
+      const registrationDate = new Date(
+        // @ts-ignore
+        avastarParsedDataFiltered[i]['timestamp']
+      );
+      const currentDate = new Date();
+      yearsDataExchange =
+        currentDate.getFullYear() - registrationDate.getFullYear();
+    }
+  }
+
   // Contains basic informations for each overview profile's block
   const overviewBlocks = [
     {
@@ -138,7 +155,7 @@ export default function OverviewProfile(props: PropsFilter) {
     {
       title: 'Years of data exchange',
       icon: HourglassIcon,
-      number: 11, // To be done once we have implemented timestamp and details in the smartParserJson and smartparserCsv
+      number: yearsDataExchange, // To be done once we have implemented timestamp and details in the smartParserJson and smartparserCsv
       tooltip: 'About years of data exchange',
     },
   ];
@@ -152,6 +169,7 @@ export default function OverviewProfile(props: PropsFilter) {
             <OverviewKeyNumber
               title={block.title}
               icon={block.icon}
+              // @ts-ignore
               number={block.number}
               tooltip={block.tooltip}
             />

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -14,7 +14,7 @@ export interface AvastarParsedDataPoint {
     | 'contractual'
     | 'other';
   platform: 'facebook' | 'google' | 'other'; // suggesting by github copilot not sure if accurate
-  timestamp?: string;
+  timestamp?: Date;
   details?: string[];
 }
 
@@ -45,7 +45,7 @@ export const getEmptyDataPoint = (): AvastarParsedDataPoint => ({
   data_origin: 'other',
   data_type: 'other',
   platform: 'other',
-  timestamp: '',
+  timestamp: undefined,
   details: []
 });
 

--- a/src/utils/smartParserJson.ts
+++ b/src/utils/smartParserJson.ts
@@ -183,8 +183,9 @@ export const smartParserJson = (
                   Object.entries(fileContent[nestedArrayName]).forEach(
                     function (item, index) {
                       let categorySelector = item[0]; // Get the name of the arrays that are parsed to know which properties from the data model must be applied to it.
-
+                      
                       const parsedDataPoint = getEmptyDataPoint();
+
                       for (
                         let k = 0;
                         k < avastarParsedDataPointProperties.length;
@@ -196,6 +197,14 @@ export const smartParserJson = (
                           avastarParsedDataPointProperties[k]
                         ];
                       }
+
+                      // Fetch facebook account creation date timestamp for years of data exchange kpis
+                      if (categorySelector == 'registration_timestamp'){
+                        const registrationDate = new Date(fileContent[nestedArrayName][categorySelector] * 1000)
+                        parsedDataPoint['timestamp'] = registrationDate
+                        console.log(categorySelector)
+                      }
+
                       smartData.push(parsedDataPoint);
                     }
                   );
@@ -210,6 +219,7 @@ export const smartParserJson = (
                         j++
                       ) {
                         const parsedDataPoint = getEmptyDataPoint();
+
                         for (
                           let k = 0;
                           k < avastarParsedDataPointProperties.length;

--- a/src/utils/smartParserJson.ts
+++ b/src/utils/smartParserJson.ts
@@ -202,7 +202,6 @@ export const smartParserJson = (
                       if (categorySelector == 'registration_timestamp'){
                         const registrationDate = new Date(fileContent[nestedArrayName][categorySelector] * 1000)
                         parsedDataPoint['timestamp'] = registrationDate
-                        console.log(categorySelector)
                       }
 
                       smartData.push(parsedDataPoint);


### PR DESCRIPTION
🚧 L'objectif de cette PR est d'automatiser l'affichage du KPI "Years of data exchange". Actuellement, le KPI affiché est 11 par défaut. Désormais, la valeur est calculée à partir de la différence d'année entre la date d'aujourd'hui et la date de création du compte facebook (et non Google car la date de création de compte est stockée dans un fichier .html que l'on ne traite pas). Les changements réalisés sont les suivants: 
* Adaptation du smartParserJson pour récupérer la date de création de compte Facebook ; 
* Update du fichier dataTypes pour corriger le type de la propriété timestamp (string --> date) ; 
* Update du composant OverviewProfile pour assigner la différence entre la date d'aujourd'hui et la date de création de compte Facebook ; 

J'en ai aussi profité pour revoir le nombre de nodes affichés dans le force graph (50 --> 100).